### PR TITLE
Add weight-per-meter axle warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # truck_calculator
 App for calculating loadingspace
+
+## Weight per meter approximation
+
+The application now calculates an approximate axle load by dividing the current
+total weight by the usable length of the selected truck. When this value
+exceeds 2,500&nbsp;kg per meter, a warning is shown:
+
+```
+ACHTUNG – mögliche Achslastüberschreitung: <value> kg/m
+```
+
+This serves only as a rough indicator and is not a substitute for official
+vehicle data.

--- a/truck_calculator/README.md
+++ b/truck_calculator/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Approximate axle load warning
+
+When calculating the loading plan the app estimates an axle load by dividing the
+total weight by the truck's usable length in meters. If this value exceeds
+2,500&nbsp;kg per meter a warning is added to the messages list.

--- a/truck_calculator/src/app/page.tsx
+++ b/truck_calculator/src/app/page.tsx
@@ -68,9 +68,10 @@ const PALLET_TYPES = {
 };
 
 const MAX_GROSS_WEIGHT_KG = 24000;
-const MAX_PALLET_SIMULATION_QUANTITY = 300; 
+const MAX_PALLET_SIMULATION_QUANTITY = 300;
 const STACKED_EUP_THRESHOLD_FOR_AXLE_WARNING = 18;
 const STACKED_DIN_THRESHOLD_FOR_AXLE_WARNING = 16;
+const MAX_WEIGHT_PER_METER_KG = 2500;
 
 
 // Core calculation logic (remains unchanged from your latest working version)
@@ -516,6 +517,17 @@ const calculateLoadingLogic = (
      if (!tempWarnings.some(w => w.includes("ACHSLAST bei DIN"))) {
         tempWarnings.push(`ACHTUNG - ACHSLAST bei DIN im AUGE BEHALTEN! (${stackedDinPallets} gestapelte DIN)`);
      }
+  }
+
+  const weightPerMeter = currentTotalWeight / (truckConfig.usableLength / 100);
+  if (
+      weightPerMeter > MAX_WEIGHT_PER_METER_KG &&
+      requestedEupQuantity !== MAX_PALLET_SIMULATION_QUANTITY &&
+      requestedDinQuantity !== MAX_PALLET_SIMULATION_QUANTITY
+  ) {
+     tempWarnings.push(
+       `ACHTUNG – mögliche Achslastüberschreitung: ${weightPerMeter.toFixed(1)} kg/m`
+     );
   }
 
   const uniqueWarnings = Array.from(new Set(tempWarnings));


### PR DESCRIPTION
## Summary
- compute weight per meter after calculating total weight
- warn when the value is above `MAX_WEIGHT_PER_METER_KG`
- document the axle load approximation in both READMEs

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.0.0-rc.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684001354e2c8330a23bac9891c1a8d6